### PR TITLE
Add SNI parser boundary checks

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,22 +1,16 @@
-/* {{{ Copyright (c) Paul R. Tagliamonte <paultag@debian.org>, 2015
+/* {{{ Copyright 2017 Paul Tagliamonte
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE. }}} */
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. }}} */
 
 package parser
 
@@ -82,10 +76,13 @@ func GetSNBlock(data []byte) ([]byte, error) {
 	}
 
 	extensionLength := int((data[index] << 8) + data[index+1])
+	if extensionLength+2 > len(data) {
+		return []byte{}, fmt.Errorf("Extension looks bonkers")
+	}
 	data = data[2 : extensionLength+2]
 
 	for {
-		if index >= len(data) {
+		if index+3 >= len(data) {
 			break
 		}
 		length := int((data[index+2] << 8) + data[index+3])


### PR DESCRIPTION
This PR adds boundary checks to the TLS extension block parser. Taken from original parser at https://github.com/paultag/sniff/blob/master/parser/parser.go